### PR TITLE
kbsecret-new: Deprecate -a/--args for -x/--terse

### DIFF
--- a/lib/kbsecret/cli/kbsecret-new
+++ b/lib/kbsecret/cli/kbsecret-new
@@ -25,6 +25,8 @@ cmd = CLI.create do |c|
     o.bool "-G", "--generate", "generate secret fields (interactive only)"
     o.string "-g", "--generator", "the generator to use for secret fields",
              default: :default
+    o.bool "-x", "--terse", "read fields from input in a terse format"
+    o.string "-i", "--ifs", "separate terse fields with this string", default: CLI.ifs
   end
 
   c.dreck do
@@ -50,18 +52,27 @@ if cmd.opts.generate?
   generator = cmd.guard { Generator.new cmd.opts[:generator] }
 end
 
-fields = if $stdin.tty? && !cmd.opts.args?
+fields = if ($stdin.tty? && !cmd.opts.args?) || cmd.opts.terse?
            prompt = TTY::Prompt.new
            klass = Record.class_for(resolved_type)
-           klass.external_fields.map do |field|
-             if cmd.opts.generate? && klass.sensitive?(field)
-               generator.secret
-             else
-               prompt.ask "#{field.capitalize}?",
-                          echo: !klass.sensitive?(field) || cmd.opts.echo?
+
+           if cmd.opts.terse?
+             fields = STDIN.read.chomp.split cmd.opts[:ifs]
+           else
+             klass.external_fields.map do |field|
+               if cmd.opts.generate? && klass.sensitive?(field)
+                 generator.secret
+               else
+                 prompt.ask "#{field.capitalize}?",
+                            echo: !klass.sensitive?(field) || cmd.opts.echo?
+               end
              end
            end
          else
+           cmd.warn <<~EOS
+             Argument input is dangerous and deprecated, and will be removed by 1.0.
+           EOS
+
            cmd.args[:fields]
          end
 

--- a/man/kbsecret-new.1.ronnpp
+++ b/man/kbsecret-new.1.ronnpp
@@ -36,46 +36,70 @@ The list of available types can be found via kbsecret-types(1).
 	the same label.
 
 * `-a`, `--args`:
-	Take fields from the trailing arguments to `kbsecret new`, instead of reading
+	Take record fields from the trailing arguments, instead of reading
 	them interactively from standard input.
+
+	**This flag is dangerous and deprecated, and will be removed by 1.0.** For similar but
+	safer functionality, see `-x`, `--terse`.
 
 * `-e`, `--echo`:
 	Echo all input to the terminal. By default, like passwd(1), sensitive input
 	fields are not echoed.
 
 	This only applies when the user is on an interactive terminal **and** has not
-	passed `-a`, `--args`.
+	passed `-a`, `--args` or `-x`, `--terse`.
 
 * `-G`, `--generate`:
 	Generate sensitive fields instead of prompting for them.
 
-	This only applies during interactive use.
+	This only applies during interactive, non-terse usage.
 
 * `-g`, `--generator` <generator>:
 	Use the given generator profile to generate sensitive fields.
 
 	If unspecified, the *default* generator is assumed.
 
+* `-x`, `--terse`:
+	Read fields from input in a terse format, similar to the formats emitted by kbsecret-login(1)
+	and kbsecret-dump-fields(1).
+
+	The field separator can be modified via the `-i`/`--ifs` option.
+
+* `-i`, `--ifs` <separator>:
+	The string used to separate fields when `-x`, `--terse` is also used.
+
+	The default field separator is read from *$IFS*, falling back to ":" if
+	*$IFS* is not set.
+
+## ENVIRONMENT
+
+The *$IFS* environment variable provides a default for `-i`, `--ifs`.
+
 ## EXAMPLES
 
 ```
-	$ kbsecret new login -a gmail bob@gmail.com pleasedonthackme
-
-	$ kbsecret new environment -a -s dev-team xyz-api XYZ_API 0xDEADBEEF
-
 	$ kbsecret new login -e netflix
 	Username? bob
 	Password? hunter2
 
 	$ kbsecret new login -G yahoo
 	Username? alice
+
+	$ kbsecret new login -x men-in-black <<< "agent_smith:ihateroaches"
+
+	$ echo "agent_jay^cricketgun" | kbsecret new login -i '^' -x men-in-black-2
+
+	$ kbsecret new login -a gmail bob@gmail.com pleasedonthackme
+
+	$ kbsecret new environment -a -s dev-team xyz-api XYZ_API 0xDEADBEEF
 ```
 
 ## SECURITY CONSIDERATIONS
 
-Using `-a`, `--args` in an interactive terminal is potentially dangerous, as your
-secret fields could be saved in your shell's history. You should limit your usage
-of `-a`, `--args` to programs.
+Using `-a`, `--args` in an interactive terminal is dangerous, as your
+secret fields could be saved in your shell's history. Similarly, any user with access to
+_/proc_ could potentially sniff your secret fields. The `-x`, `--terse` flag is functionally
+identical to `-a`, `--args`, but uses standard input to avoid this problem.
 
 Enabling terminal echo with `-e`, `--echo` is less secure than the
 default interactive input, unless you know for a fact that nobody is looking over your


### PR DESCRIPTION
This commit marks the -a/--args flag to `kbsecret new` as deprecated,
and spits a warning at the user should they try to use it. The
functionality of -a/--args will be removed entirely by 1.0.

The new -x/--terse option serves as a replacement for -a/--args,
accepting a tersely-formatted string of fields on standard input.
The behavior of this flag can be modified via -i/--ifs.
Compare this to `kbsecret login` and `kbsecret dump-fields`.

In short, usages like this:

    $ kbsecret new login -a foo bar baz

can be turned into this:

    $ kbsecret new login -x foo <<< "bar:baz"

Which isn't substantially longer, and is much safer.

Closes #11.