### PR TITLE
Fix branch reference for coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ KBSecret
 
 [![Gem Version](https://badge.fury.io/rb/kbsecret.svg)](https://badge.fury.io/rb/kbsecret)
 [![Build Status](https://travis-ci.org/woodruffw/kbsecret.svg?branch=master)](https://travis-ci.org/woodruffw/kbsecret)
-[![Coverage Status](https://coveralls.io/repos/github/woodruffw/kbsecret/badge.svg?branch=master)](https://coveralls.io/github/woodruffw/kbsecret?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/woodruffw/kbsecret/badge.svg?branch=coveralls)](https://coveralls.io/github/woodruffw/kbsecret?branch=coveralls)
 
 *Note*: This is still a work in process. Use it with caution.
 


### PR DESCRIPTION
Thank you for contributing to KBSecret! Please fill out the items below to help us merge
your work more quickly.

- [N/A] Have you run `make test` locally and ensured that all tests pass?
- [N/A] Have you run `make coverage` locally and ensured that coverage did not drop?

*If* you're changing something in the library:
- [N/A] Have you introduced unit tests for your changes?

*If* you're changing something in the CLI:
- [N/A] Have you updated the manual pages and shell completion (if necessary)?

Please describe your changes briefly here. Thank you!
- Changed branch reference in README.md so the coverage badge actually works